### PR TITLE
add: node `transparency` based on weight

### DIFF
--- a/islands/Graph.tsx
+++ b/islands/Graph.tsx
@@ -39,7 +39,7 @@ const getNodeColor = (node: Node) => {
   const g = Math.round(149 - (100 * value));
   const b = Math.round(237 - (100 * value));
 
-  return node.color ?? `rgb(${r}, ${g}, ${b})`;
+  return node.color ?? `rgba(${r}, ${g}, ${b}, ${node.size})`;
 };
 
 const Graph: React.FC<{ data: GraphData; zoom: number }> = ({ data }) => {


### PR DESCRIPTION
This PR makes nodes more transparent the less assigned weight they have. This makes "important" nodes easier to see in comparison with their "less important" counterparts.

<img width="752" alt="image" src="https://github.com/user-attachments/assets/3cd8cb31-d2d0-45cf-9282-09f81df7fd20" />
